### PR TITLE
[feat] set channel name bold after reconnect #155 #156

### DIFF
--- a/src/hooks/use-change-chat.tsx
+++ b/src/hooks/use-change-chat.tsx
@@ -1,4 +1,5 @@
-import useFetch from 'hooks/use-fetch';
+import useChatAlert from 'hooks/use-chat-alert';
+import { chatSocket } from 'pages/chat/chat-socket';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { ChatRoomType } from 'ts/enums/chat-room-type.enum';
 import { ChatSidebarStatus } from 'ts/enums/chat-sidebar-status.enum';
@@ -17,7 +18,7 @@ const useChangeChat = () => {
 	const setChatHeaderState = useSetRecoilState(chatHeaderState);
 	const setChatRoomList = useSetRecoilState(chatListState);
 	const setSidebarState = useSetRecoilState(chatSidebarState);
-	const getData = useFetch();
+	const setAlertModal = useChatAlert();
 	const blockedUser = useRecoilValue(userFriendsState).blockedFriends as User[];
 
 	const chatsWithoutBlocked = (chats: Chat[]): Chat[] => {
@@ -26,29 +27,9 @@ const useChangeChat = () => {
 		});
 	};
 
-	const setChat = (
-		chat: ChatRoom | Dm | null,
-		closeSidebar: boolean = true
-	) => {
-		if (chat) {
-			(async () => {
-				await getData('get', `/chat-rooms/${chat?.id}/chats`)
-					.then((res) => {
-						if (res.ok) {
-							return res.json();
-						}
-						throw Error(res.statusText);
-					})
-					.then((chats) =>
-						setChatState({
-							chatRoom: chat,
-							chats: chatsWithoutBlocked(chats),
-						})
-					)
-					.catch((err) => console.log('inside setChat', err));
-			})();
-
-			if (chat.roomType === ChatRoomType.DM) {
+	const markChannelAsRead = (chat: ChatRoom | Dm) => {
+		switch (chat.roomType) {
+			case ChatRoomType.DM:
 				setChatRoomList((pre) => ({
 					...pre,
 					dmList: pre.dmList.map((dm) => {
@@ -58,7 +39,8 @@ const useChangeChat = () => {
 						return dm;
 					}),
 				}));
-			} else {
+				break;
+			default:
 				setChatRoomList((pre) => ({
 					...pre,
 					channelList: pre.channelList.map((channel) => {
@@ -68,7 +50,30 @@ const useChangeChat = () => {
 						return channel;
 					}),
 				}));
-			}
+		}
+	};
+
+	const setChat = (
+		chat: ChatRoom | Dm | null,
+		closeSidebar: boolean = true
+	) => {
+		if (chat) {
+			chatSocket.emit(
+				'getChats',
+				{ roomId: chat.id },
+				(response: { status: number; chats: Chat[] }) => {
+					if (response.status === 200) {
+						setChatState({
+							chatRoom: chat,
+							chats: chatsWithoutBlocked(response.chats),
+						});
+					} else {
+						setAlertModal();
+					}
+				}
+			);
+
+			markChannelAsRead(chat);
 		} else {
 			setChatState({ chatRoom: null, chats: [] });
 		}

--- a/src/hooks/use-change-chat.tsx
+++ b/src/hooks/use-change-chat.tsx
@@ -1,17 +1,15 @@
 import useChatAlert from 'hooks/use-chat-alert';
 import { chatSocket } from 'pages/chat/chat-socket';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 import { ChatRoomType } from 'ts/enums/chat-room-type.enum';
 import { ChatSidebarStatus } from 'ts/enums/chat-sidebar-status.enum';
 import { ChatRoom } from 'ts/interfaces/chat-room.model';
 import { Chat } from 'ts/interfaces/chat.model';
 import { Dm } from 'ts/interfaces/dm.model';
-import User from 'ts/interfaces/user.model';
 import { chatHeaderState } from 'ts/states/chat-header-state';
 import { chatListState } from 'ts/states/chat-list.state';
 import { chatSidebarState } from 'ts/states/chat-sidebar-state';
 import { chatState } from 'ts/states/chat-state';
-import { userFriendsState } from 'ts/states/user/user-friends-state';
 
 const useChangeChat = () => {
 	const setChatState = useSetRecoilState(chatState);
@@ -19,13 +17,6 @@ const useChangeChat = () => {
 	const setChatRoomList = useSetRecoilState(chatListState);
 	const setSidebarState = useSetRecoilState(chatSidebarState);
 	const setAlertModal = useChatAlert();
-	const blockedUser = useRecoilValue(userFriendsState).blockedFriends as User[];
-
-	const chatsWithoutBlocked = (chats: Chat[]): Chat[] => {
-		return chats.filter((chat) => {
-			return !blockedUser.find((user) => user.id === chat.user.user.id);
-		});
-	};
 
 	const markChannelAsRead = (chat: ChatRoom | Dm) => {
 		switch (chat.roomType) {
@@ -65,7 +56,11 @@ const useChangeChat = () => {
 					if (response.status === 200) {
 						setChatState({
 							chatRoom: chat,
-							chats: chatsWithoutBlocked(response.chats),
+							chats: response.chats.sort(
+								(a, b) =>
+									new Date(a.sentTime).getTime() -
+									new Date(b.sentTime).getTime()
+							),
 						});
 					} else {
 						setAlertModal();

--- a/src/pages/chat/components/field/chat-field.tsx
+++ b/src/pages/chat/components/field/chat-field.tsx
@@ -21,14 +21,14 @@ const ChatField = () => {
 	const chats = chat.chats;
 
 	useEffect(() => {
-		setShowedChats(chatsWithoutBlocked(chats));
-	}, [chats, blockedUser]);
-
-	useEffect(() => {
 		if (scrollRef.current) {
 			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
 		}
-	}, [scrollRef, chatRoom, chats]);
+	}, [scrollRef, chatRoom, showedChats]);
+
+	useEffect(() => {
+		setShowedChats(chatsWithoutBlocked(chats));
+	}, [chats, blockedUser]);
 
 	const chatsWithoutBlocked = (chats: Chat[]): Chat[] => {
 		return chats.filter((chat) => {

--- a/src/pages/chat/components/field/chat-field.tsx
+++ b/src/pages/chat/components/field/chat-field.tsx
@@ -75,7 +75,7 @@ const ChatField = () => {
 					hasTopBorder={
 						id === 0
 							? true
-							: hasTopBorder(chats[id - 1].sentTime, chat.sentTime)
+							: hasTopBorder(showedChats[id - 1].sentTime, chat.sentTime)
 					}
 					key={id}
 				/>

--- a/src/pages/chat/components/field/chat-field.tsx
+++ b/src/pages/chat/components/field/chat-field.tsx
@@ -1,26 +1,40 @@
 import ChannelHeader from 'pages/chat/components/field/channel-header';
 import ChatItem from 'pages/chat/components/field/chat-item';
 import DmHeader from 'pages/chat/components/field/dm-header';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { ChatRoomType } from 'ts/enums/chat-room-type.enum';
 import { ChatRoom } from 'ts/interfaces/chat-room.model';
+import { Chat } from 'ts/interfaces/chat.model';
 import { Dm } from 'ts/interfaces/dm.model';
+import User from 'ts/interfaces/user.model';
 import { chatState } from 'ts/states/chat-state';
+import { userFriendsState } from 'ts/states/user/user-friends-state';
 
 const ChatField = () => {
 	const chat = useRecoilValue(chatState);
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const blockedUser = useRecoilValue(userFriendsState).blockedFriends as User[];
+	const [showedChats, setShowedChats] = useState<Chat[]>([]);
+
 	const chatRoom = chat.chatRoom;
-	const chats = [...chat.chats].sort(
-		(a, b) => new Date(a.sentTime).getTime() - new Date(b.sentTime).getTime()
-	);
+	const chats = chat.chats;
+
+	useEffect(() => {
+		setShowedChats(chatsWithoutBlocked(chats));
+	}, [chats, blockedUser]);
 
 	useEffect(() => {
 		if (scrollRef.current) {
 			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
 		}
 	}, [scrollRef, chatRoom, chats]);
+
+	const chatsWithoutBlocked = (chats: Chat[]): Chat[] => {
+		return chats.filter((chat) => {
+			return !blockedUser.find((user) => user.id === chat.user.user.id);
+		});
+	};
 
 	if (chatRoom === null) {
 		return <></>;
@@ -55,7 +69,7 @@ const ChatField = () => {
 			) : (
 				<ChannelHeader channel={chatRoom as ChatRoom} />
 			)}
-			{chats.map((chat, id) => (
+			{showedChats.map((chat, id) => (
 				<ChatItem
 					chat={chat}
 					hasTopBorder={

--- a/src/pages/chat/components/sidebar/chat-member-invite-tap.tsx
+++ b/src/pages/chat/components/sidebar/chat-member-invite-tap.tsx
@@ -43,7 +43,8 @@ const ChatMemberInviteTap = (props: {
 							(participant) =>
 								participant.user.id === friend.id &&
 								(participant.status === ChatParticipantStatus.DEFAULT ||
-									participant.status === ChatParticipantStatus.MUTED)
+									participant.status === ChatParticipantStatus.MUTED ||
+									participant.status === ChatParticipantStatus.BANNED)
 						) && friend.nickname.includes(input)
 				)
 				.sort((a, b) => a.nickname.localeCompare(b.nickname))

--- a/src/pages/chat/handle-chat-socket.tsx
+++ b/src/pages/chat/handle-chat-socket.tsx
@@ -33,7 +33,10 @@ const HandleChatSocket = () => {
 		}));
 	};
 
-	const markDmAsUnread = (roomId: number) => {
+	const markDmAsUnread = (roomId: number, newChat: Chat) => {
+		if (blockedUser.some((user) => user.id === newChat.user.user.id)) {
+			return;
+		}
 		setChatRoomList((pre) => ({
 			...pre,
 			channelList: pre.channelList.map((channel) => {
@@ -86,7 +89,7 @@ const HandleChatSocket = () => {
 						addNewChat(newChat);
 						chatSocket.emit('readChat', { roomId });
 					} else {
-						markDmAsUnread(roomId);
+						markDmAsUnread(roomId, newChat);
 					}
 				}
 			);
@@ -135,7 +138,7 @@ const HandleChatSocket = () => {
 				'getNewChatOnDm',
 				(data: { roomId: number; newChat: Chat }) => {
 					const { roomId } = data;
-					markDmAsUnread(roomId);
+					markDmAsUnread(roomId, data.newChat);
 				}
 			);
 		}

--- a/src/pages/chat/handle-chat-socket.tsx
+++ b/src/pages/chat/handle-chat-socket.tsx
@@ -80,6 +80,8 @@ const HandleChatSocket = () => {
 		}));
 	};
 
+	/* mamage connection */
+
 	useEffect(() => {
 		if (token !== undefined && chatSocket.disconnected) {
 			chatSocket.io.opts.extraHeaders = {
@@ -91,6 +93,8 @@ const HandleChatSocket = () => {
 			chatSocket.disconnect();
 		};
 	}, [token]);
+
+	/* listener */
 
 	useEffect(() => {
 		if (chat.chatRoom) {

--- a/src/pages/chat/handle-chat-socket.tsx
+++ b/src/pages/chat/handle-chat-socket.tsx
@@ -33,17 +33,14 @@ const HandleChatSocket = () => {
 		}));
 	};
 
-	const markDmAsUnread = (roomId: number, newChat: Chat) => {
-		if (blockedUser.some((user) => user.id === newChat.user.user.id)) {
-			return;
-		}
+	const markDmAsUnread = (roomId: number) => {
 		setChatRoomList((pre) => ({
 			...pre,
-			channelList: pre.channelList.map((channel) => {
-				if (channel.id === roomId) {
-					return { ...channel, leftToRead: true };
+			dmList: pre.dmList.map((dm) => {
+				if (dm.id === roomId) {
+					return { ...dm, leftToRead: true };
 				}
-				return channel;
+				return dm;
 			}),
 		}));
 	};
@@ -70,7 +67,7 @@ const HandleChatSocket = () => {
 			chatSocket.emit('readChat', { roomId });
 			return;
 		}
-		markDmAsUnread(roomId, newChat);
+		markDmAsUnread(roomId);
 	};
 
 	const deleteChatRoom = (roomId: number) => {

--- a/src/pages/chat/handle-chat-socket.tsx
+++ b/src/pages/chat/handle-chat-socket.tsx
@@ -105,13 +105,13 @@ const HandleChatSocket = () => {
 			chatSocket.on('chatRoomDeleted', (roomId: number) => {
 				if (roomId === chat.chatRoom?.id) {
 					setChatRoom(null);
-					setChatRoomList((pre) => ({
-						...pre,
-						channelList: pre.channelList.filter(
-							(channel) => channel.id !== roomId
-						),
-					}));
 				}
+				setChatRoomList((pre) => ({
+					...pre,
+					channelList: pre.channelList.filter(
+						(channel) => channel.id !== roomId
+					),
+				}));
 			});
 
 			chatSocket.off('updateChatRoomOnList');

--- a/src/pages/chat/handle-chat-socket.tsx
+++ b/src/pages/chat/handle-chat-socket.tsx
@@ -1,5 +1,4 @@
 import { getJwtValue } from 'components/utils/cookieUtils';
-import useAddChat from 'hooks/use-add-chat';
 import useChangeChat from 'hooks/use-change-chat';
 import { chatSocket } from 'pages/chat/chat-socket';
 import { useEffect } from 'react';
@@ -20,7 +19,7 @@ const HandleChatSocket = () => {
 	const token = getJwtValue();
 	const user = useRecoilValue(userState) as User;
 	const blockedUser = useRecoilValue(userFriendsState).blockedFriends as User[];
-	const addNewChat = useAddChat();
+	const setChat = useSetRecoilState(chatState);
 
 	const markChannelAsUnread = (roomId: number) => {
 		setChatRoomList((pre) => ({
@@ -44,6 +43,10 @@ const HandleChatSocket = () => {
 				return channel;
 			}),
 		}));
+	};
+
+	const addNewChat = (newChat: Chat) => {
+		setChat((pre) => ({ ...pre, chats: [...pre.chats, newChat] }));
 	};
 
 	useEffect(() => {


### PR DESCRIPTION
<!--
PR은 여러 feat를 묶어서 올리셔도 괜찮아요.

✅ 확인 목록
- 제출 전 형식에 맞춰서 작성했나요?
- 정상인 경우와 비정적인 경우의 테스트를 진행했나요?
-->
## 🌷 Summary
<!--
TL;DR처럼 긴 내용을 읽지 않으실 분들에게 이것만 봐도 대강 알 수 있게 쉽게 설명해주세요
-->

- 읽지않는 메시지가 있는 채널이름은 폰트 굵기가 다르도록 수정했습니다.
- 에러들을 수정했습니다.

## 📢 Description
<!--
다른 개발자들에게 어떤 내용의 PR인지 잘 설명해주세요
-->

- 밴 당한 참여자는 초대 목록에 나오지않도록 했습니다.
- 차단한 유저의 메시지가 보이지 않도록 수정했습니다.
- 채팅 내역을 받기위해 기존 http통신을 사용하는 방식에서 소켓 통신으로 수정했습니다.
- 사용자가 마지막으로 메시지를 확인한 시간을 기록하여 재접속했을 때 읽지않은 메시지가 있는 채널은 채널명 폰트가 달라지도록 했습니다.
- 킥, 밴된 참여자가 채팅방을 나가게되도록 수정했습니다.

## 🐙 Related Issue number
<!--
올리는 PR과 연관되는 feat와 view를 연결해주세요!
view를 먼저 언급해주세요
-->
- #155
- #156
- 
<!-- ScreenShot [optional] -->
